### PR TITLE
allow user to specify custom render handler

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,11 +49,14 @@ module.exports.title = function(str) {
 
 
 /**
- * Render a Jade view using app locals.
+ * Render a view using app locals.
  *
- * This is necessary because our library can't rely on the developer using Jade
- * view as well -- so this allows us to use Jade templates for our library
- * views, without negatively affecting the developer's application.
+ * By default, use jade as it is necessary because our library can't rely
+ * on the developer using Jade view as well -- so this allows us to use
+ * Jade templates for our library views, without negatively affecting the
+ * developer's application.
+ *
+ * however, if configured, use the developer's supplied render handler
  *
  * @method
  * @private
@@ -68,10 +71,20 @@ module.exports.render = function(view, res, options) {
   mixin(options, res.locals);
   mixin(options, res.app.get('stormpathTemplateContext'));
 
-  jade.renderFile(view, options, function(err, html) {
-    if (err) throw err;
-    res.send(html);
-  });
+  var renderHandler = res.app.get('stormpathRenderHandler');
+
+  if (renderHandler) {
+
+    renderHandler(view,res,options);
+
+  } else {
+
+    jade.renderFile(view, options, function(err, html) {
+      if (err) throw err;
+      res.send(html);
+    });
+  }
+
 };
 
 
@@ -463,6 +476,9 @@ module.exports.initSettings = function(app, opts) {
 
     // Template data
     app.set('stormpathTemplateContext', opts.templateContext || JSON.parse(process.env.STORMPATH_TEMPLATE_CONTEXT || '{}') || {});
+
+    // render handler
+    app.set('stormpathRenderHandler', opts.renderHandler|| null);
 
     // Which views should we render?
     app.set('stormpathRegistrationView', opts.registrationView || process.env.STORMPATH_REGISTRATION_VIEW || __dirname + '/views/register.jade');


### PR DESCRIPTION
app.use(stormpath.init(app, {
...
    renderHandler: function(view,res,options) {
      // custom render handling here - use jade, handlebars etc or just set some extra form options
    },
...
}

adding this option allows the developer to use their own view engine (jade / handlebars etc) when rendering any of the stormpath views. It also allows the developer to add / remove options before the view is rendered