### PR TITLE
Remove the unnecessary files from the node module.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+docs
+test
+.travis.yml
+.gitignore
+README.md


### PR DESCRIPTION
The .npmignore will remove the documentation, tests, and other unnecessary code for production use. This cuts out roughly 20MB of files that aren't necessary to run in production, and it only affects the publish to the npm registry, not the entire project.