### PR TITLE
Adds support for passing in a caching client directly

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -68,6 +68,7 @@ module.exports.init = function(app, opts) {
   app.set('stormpathCacheTTL', opts.cacheTTL || parseInt(process.env.STORMPATH_CACHE_TTL) || 300);
   app.set('stormpathCacheTTI', opts.cacheTTI || parseInt(process.env.STORMPATH_CACHE_TTI) || 300);
   app.set('stormpathCacheOptions', opts.cacheOptions || JSON.parse(process.env.STORMPATH_CACHE_OPTIONS || '{}') || {});
+  app.set('stormpathCacheClient', opts.cacheClient || undefined);
 
   // Oauth configuration.
   app.set('stormpathOauthTTL', opts.oauthTTL || parseInt(process.env.STORMPATH_OAUTH_TTL) || 3600);

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -46,6 +46,11 @@ function initClient(app) {
       options: app.get('stormpathCacheOptions'),
     };
 
+    if (app.get('stormpathCacheClient')) {
+      cacheOptions.client = app.get('stormpathCacheClient');
+      delete cacheOptions.connection;
+    }
+
     if (app.get('stormpathApiKeyId') && app.get('stormpathApiKeySecret')) {
       app.set('stormpathClient', new stormpath.Client({
         apiKey: new stormpath.ApiKey(


### PR DESCRIPTION
We found ourselves wanting to use a pre-configured Redis connection, specifically for the authentication support.  I believe the solution will work for a pre-configured Memcached client, too.

I reached the application limit when running the full suite of tests.  If you have a workaround, I am happy to run the tests locally to verify this changeset.