### PR TITLE
Fixing order of config validation

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Config = require('express-stormpath-config');
+var ExpressStormpathConfig = require('express-stormpath-config');
 var async = require('async');
 var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser');
@@ -28,16 +28,10 @@ var version = require('../package.json').version;
 function initClient(app, opts) {
   var userAgent = 'stormpath-express/' + version + ' ' + 'express/' + expressVersion;
   opts.userAgent = userAgent;
-  var config = new Config(opts);
 
   // If the options aren't valid for any reason, we'll throw a nice
   // human-readable error so the developer can quickly fix the configuration
   // issue(s) that may be present.
-  config.validate(function(err) {
-    if (err) {
-      throw err;
-    }
-  });
 
   var client = new stormpath.Client(opts);
 
@@ -53,6 +47,11 @@ function initClient(app, opts) {
   }
 
   client.on('ready', function() {
+    new ExpressStormpathConfig(client.config).validate(function(err) {
+      if (err) {
+        throw err;
+      }
+    });
     app.set('stormpathClient', client);
     app.set('stormpathConfig', client.config);
   });


### PR DESCRIPTION
We shouldn't validate until after the underlying Node SDK has run, as it populates any values from the environment and subsequent resource calls to the API